### PR TITLE
feat: rename migrate command to init with conditional behavior

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Generate AI configurations
         run: bunx dot-ai@latest run
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
       - name: Generate AI configurations
         run: bunx dot-ai@latest run
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { runGeneration } from "./generator.ts";
-import { runMigration } from "./migrator.ts";
+import { runInit } from "./migrator.ts";
 
 async function checkGitStatus() {
   try {
@@ -29,21 +29,21 @@ async function main() {
   if (args.length === 0) {
     console.log("Usage: dot-ai <command>");
     console.log("Commands:");
-    console.log("  run      Generate AI provider configs from .ai/ folder");
-    console.log("  migrate  Migrate existing provider configs to .ai/ folder");
+    console.log("  run   Generate AI provider configs from .ai/ folder");
+    console.log("  init  Initialize .ai/ folder structure or migrate existing configs");
     process.exit(1);
   }
 
   if (args[0] === "run") {
     await runGeneration();
-  } else if (args[0] === "migrate") {
-    await runMigration();
+  } else if (args[0] === "init") {
+    await runInit();
   } else {
     console.error(`❌ Error: Unknown command '${args[0]}'`);
     console.log("Usage: dot-ai <command>");
     console.log("Commands:");
-    console.log("  run      Generate AI provider configs from .ai/ folder");
-    console.log("  migrate  Migrate existing provider configs to .ai/ folder");
+    console.log("  run   Generate AI provider configs from .ai/ folder");
+    console.log("  init  Initialize .ai/ folder structure or migrate existing configs");
     process.exit(1);
   }
 }

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -235,3 +235,189 @@ export async function runMigration(): Promise<void> {
     console.log("   Please review .ai/mcp.json and resolve conflicts manually");
   }
 }
+
+async function createInitialAIStructure(): Promise<void> {
+  // Create .ai structure
+  await ensureDirectoryExists(".ai/rules");
+  await ensureDirectoryExists(".ai/commands");
+
+  // Create dummy instructions.md
+  const dummyInstructions = `# AI Instructions
+
+This is your AI assistant configuration file. You can:
+
+- Add project-specific instructions here
+- Include coding conventions and preferences  
+- Define your preferred communication style
+- Add any context that helps the AI understand your project
+
+## Project Context
+
+Add information about your project here.
+
+## Coding Style
+
+Add your preferred coding patterns and conventions here.
+`;
+
+  await Bun.write(".ai/instructions.md", dummyInstructions);
+
+  // Create dummy rule file
+  const dummyRule = `---
+name: example-rule
+description: An example rule showing the format
+---
+
+# Example Rule
+
+This is an example rule file. You can create multiple rule files in the rules/ directory.
+
+Each rule can have:
+- Frontmatter with metadata (name, description, etc.)
+- Markdown content with specific instructions or patterns
+
+Delete this file and add your own rules as needed.
+`;
+
+  await Bun.write(".ai/rules/example.md", dummyRule);
+
+  // Create dummy command file
+  const dummyCommand = `# example-command
+
+This is an example command file. You can create multiple command files in the commands/ directory.
+
+Commands can contain:
+- Specific instructions for tasks
+- Code templates
+- Workflow descriptions
+
+Delete this file and add your own commands as needed.
+`;
+
+  await Bun.write(".ai/commands/example.md", dummyCommand);
+
+  // Create empty MCP config
+  const emptyMCP = {
+    mcpServers: {}
+  };
+
+  await Bun.write(".ai/mcp.json", JSON.stringify(emptyMCP, null, 2));
+}
+
+export async function runInit(): Promise<void> {
+  // Check if .ai already exists
+  try {
+    await Bun.$`test -d .ai`.quiet();
+    console.log("✅ .ai folder already exists - nothing to do!");
+    return;
+  } catch (error) {
+    // Directory doesn't exist, continue
+  }
+
+  // Check for existing provider files
+  const detected = await detectProviderFiles();
+
+  // Check if we found any provider files
+  const hasAnyFiles =
+    detected.claude ||
+    detected.gemini ||
+    detected.agents ||
+    detected.cursorRules.length > 0 ||
+    detected.claudeCommands.length > 0 ||
+    detected.mcp ||
+    detected.geminiSettings ||
+    detected.opencode;
+
+  if (hasAnyFiles) {
+    // Run migration logic
+    console.log("🔄 Found existing AI provider files, migrating to .ai/ folder...");
+    
+    // Create .ai structure
+    await ensureDirectoryExists(".ai/rules");
+    await ensureDirectoryExists(".ai/commands");
+
+    let createdFiles: string[] = [];
+
+    // Migrate instructions - concatenate CLAUDE.md + GEMINI.md + AGENTS.md
+    let instructions = "";
+    if (detected.claude) {
+      instructions += await Bun.file(detected.claude).text();
+    }
+    if (detected.gemini) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(detected.gemini).text();
+    }
+    if (detected.agents) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(detected.agents).text();
+    }
+    if (instructions) {
+      await Bun.write(".ai/instructions.md", instructions);
+      createdFiles.push(".ai/instructions.md");
+    }
+
+    // Migrate rules (.mdc → .md)
+    for (const ruleFile of detected.cursorRules) {
+      const content = await Bun.file(ruleFile).text();
+      const filename = path.basename(ruleFile).replace(".mdc", ".md");
+      await Bun.write(`.ai/rules/${filename}`, content);
+    }
+    if (detected.cursorRules.length > 0) {
+      createdFiles.push(`.ai/rules/ (${detected.cursorRules.length} files)`);
+    }
+
+    // Migrate commands
+    for (const commandFile of detected.claudeCommands) {
+      const content = await Bun.file(commandFile).text();
+      const filename = path.basename(commandFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+    }
+    if (detected.claudeCommands.length > 0) {
+      createdFiles.push(
+        `.ai/commands/ (${detected.claudeCommands.length} files)`,
+      );
+    }
+
+    // Merge MCP configs
+    const { merged, duplicates } = await extractAllMCPConfigs();
+    const serverCount = Object.keys(merged.mcpServers).length;
+
+    if (serverCount > 0) {
+      await Bun.write(".ai/mcp.json", JSON.stringify(merged, null, 2));
+      createdFiles.push(`.ai/mcp.json (${serverCount} servers)`);
+    } else {
+      // Create empty MCP config if no servers found
+      await Bun.write(".ai/mcp.json", JSON.stringify({ mcpServers: {} }, null, 2));
+      createdFiles.push(".ai/mcp.json");
+    }
+
+    // Report results
+    console.log("✅ Migration completed!");
+    console.log("");
+    console.log("Created:");
+    for (const file of createdFiles) {
+      console.log(`  ${file}`);
+    }
+
+    if (duplicates.length > 0) {
+      console.log("");
+      console.log(`⚠️  Duplicate MCP servers found: ${duplicates.join(", ")}`);
+      console.log("   Please review .ai/mcp.json and resolve conflicts manually");
+    }
+  } else {
+    // No provider files found, create initial structure with dummy content
+    console.log("🚀 Initializing new .ai/ folder with example content...");
+    
+    await createInitialAIStructure();
+
+    console.log("✅ Initialization completed!");
+    console.log("");
+    console.log("Created:");
+    console.log("  .ai/instructions.md");
+    console.log("  .ai/rules/example.md");
+    console.log("  .ai/commands/example.md");
+    console.log("  .ai/mcp.json");
+    console.log("");
+    console.log("💡 Edit the files in .ai/ to customize your AI assistant configuration.");
+  }
+}


### PR DESCRIPTION
Renamed the `migrate` command to `init` with new conditional behavior:

- If no AI files exist: creates .ai/ folder with dummy content
- If AI files exist: migrates them to .ai/ folder (existing behavior)

Fixes #2

Generated with [Claude Code](https://claude.ai/code)