### PR TITLE
feat: add compatibility for 11 new AI coding assistants

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -1,0 +1,409 @@
+# AI Provider Compatibility Research
+
+This document outlines the configuration file formats and locations for all supported AI coding assistants.
+
+## Summary Table
+
+| Provider               | Instructions                    | Rules/Agents       | Commands/Workflows       | MCP Support        | Special Features                              |
+| ---------------------- | ------------------------------- | ------------------ | ------------------------ | ------------------ | --------------------------------------------- |
+| **Windsurf**           | Memories                        | Built-in           | -                        | ✅ MCP servers     | Cascade agent, memories                       |
+| **Qoder**              | Chat context                    | -                  | Quest Mode               | ✅ MCP servers     | Quest Mode, Repo Wiki                         |
+| **TRAE**               | Built-in                        | Agents             | CUE tool                 | -                  | SOLO mode, dual development modes             |
+| **Jules**              | -                               | AGENTS.md          | -                        | -                  | Virtual machine execution, GitHub integration |
+| **Qwen Code**          | REPL                            | -                  | Custom commands          | ✅ OpenAI protocol | SubAgent support, free 2000 daily requests    |
+| **Gemini CLI**         | -                               | -                  | Custom commands          | ✅ MCP servers     | REPL, checkpointing, sandboxing               |
+| **GitHub Copilot CLI** | -                               | ~/.copilot/agents/ | -                        | ✅ MCP servers     | Session management, custom agents             |
+| **Kiro**               | Steering                        | -                  | Hooks                    | ✅ MCP servers     | Specs, hooks, steering, privacy-first         |
+| **VS Code Copilot**    | .github/copilot-instructions.md | .github/agents/    | .github/copilot-prompts/ | ✅ MCP servers     | Custom agents, prompt files, language models  |
+| **Antigravity**        | ~/.gemini/GEMINI.md             | .agent/rules/      | .agent/workflows/        | ✅ MCP servers     | Task groups, browser subagent                 |
+| **Dropstone**          | -                               | -                  | Autonomous workflows     | -                  | AGI capabilities, self-learning               |
+
+---
+
+## Detailed Provider Analysis
+
+### 1. Windsurf
+
+**Documentation:** https://docs.windsurf.com/
+
+#### Configuration Files:
+
+- **Memories**: Cascade can store and recall information
+- **MCP Servers**: Extends agent capabilities
+- **Settings**: Import from VS Code/Cursor
+
+#### Features:
+
+- Cascade: Agentic chatbot
+- Context awareness
+- Terminal integration
+- Workflows automation
+- App deploys
+
+#### File Structure:
+
+```
+project/
+├── .windsurf/
+│   ├── mcp.json          # MCP server configurations
+│   └── memories/          # Stored memories
+```
+
+---
+
+### 2. Qoder
+
+**Documentation:** https://docs.qoder.com/
+
+#### Configuration Files:
+
+- **Quest Mode**: Asynchronous development tasks
+- **Repo Wiki**: Project structure analysis
+- **MCP Servers**: External tools and services
+
+#### Features:
+
+- Quest Mode: Delegate complex tasks
+- Enhanced context engineering
+- Repo Wiki: Deep code analysis
+- CLI support
+- JetBrains plugin
+
+#### File Structure:
+
+```
+project/
+├── .qoder/
+│   └── mcp.json          # MCP server configurations
+```
+
+---
+
+### 3. TRAE
+
+**Documentation:** https://docs.trae.ai/
+
+#### Configuration Files:
+
+- **Agent System**: Freely configurable agents
+- **CUE**: Agent programming tool
+- **SOLO Mode**: AI-led development
+
+#### Features:
+
+- SOLO Coder: Complex project development
+- SOLO Builder: Rapid web app building
+- Dual development modes (IDE + SOLO)
+- Agent marketplace
+
+#### File Structure:
+
+```
+project/
+├── .trae/
+│   └── agents/           # Custom agents
+```
+
+---
+
+### 4. Jules (Google)
+
+**Documentation:** https://jules.google/docs
+
+#### Configuration Files:
+
+- **AGENTS.md**: Agent/tool descriptions in repository root
+
+#### Features:
+
+- Virtual machine execution
+- GitHub integration
+- Environment setup scripts
+- Task planning and execution
+- Browser notifications
+
+#### File Structure:
+
+```
+project/
+├── AGENTS.md             # Agent descriptions (automatically detected)
+```
+
+---
+
+### 5. Qwen Code
+
+**Documentation:** https://qwenlm.github.io/qwen-code-docs/
+
+#### Configuration Files:
+
+- **Custom commands**: REPL environment
+- **SubAgent support**: Specialized development tasks
+- **OpenAI Protocol**: Compatible with multiple AI providers
+
+#### Features:
+
+- Interactive REPL
+- File system operations
+- SubAgent support
+- 2000 free daily requests via QwenChat OAuth
+- MIT licensed
+
+#### File Structure:
+
+```
+~/.qwen-code/
+├── config.json           # Configuration
+└── commands/             # Custom commands
+```
+
+---
+
+### 6. Gemini CLI
+
+**Documentation:** https://geminicli.com/docs/
+
+#### Configuration Files:
+
+- **Custom commands**: Frequently used prompts
+- **Settings**: ~/.gemini/settings.json
+- **MCP Servers**: External tool integration
+
+#### Features:
+
+- Interactive REPL
+- Checkpointing
+- Sandbox mode
+- Token caching
+- Trusted folders
+- Themes
+
+#### File Structure:
+
+```
+~/.gemini/
+├── settings.json         # CLI settings
+├── commands/             # Custom commands
+└── mcp-config.json       # MCP server configurations
+```
+
+---
+
+### 7. GitHub Copilot CLI
+
+**Documentation:** https://github.com/features/copilot/cli
+
+#### Configuration Files:
+
+- **~/.copilot/agents/**: User-defined custom agents
+- **~/.copilot/config**: User preferences and model selection
+- **~/.copilot/mcp-config.json**: MCP server configurations
+- **.github/agents/**: Repository-specific agents
+
+#### Features:
+
+- Session management
+- Custom agents (user, repo, org-level)
+- MCP server support
+- Model selection
+- Tool allow/deny lists
+
+#### File Structure:
+
+```
+~/.copilot/
+├── config                # User preferences
+├── agents/               # User-defined agents
+├── mcp-config.json       # MCP configurations
+└── session-state         # Session history
+
+project/
+├── .github/
+│   └── agents/           # Repository-specific agents
+```
+
+---
+
+### 8. Kiro
+
+**Documentation:** https://kiro.dev/docs/
+
+#### Configuration Files:
+
+- **Specs**: Structured feature specifications
+- **Hooks**: Automated task triggers
+- **Steering**: Custom rules and context
+- **MCP Servers**: External tools
+
+#### Features:
+
+- Specs-based planning
+- Hooks automation
+- Agentic chat
+- Privacy-first approach
+- IDE and CLI versions
+
+#### File Structure:
+
+```
+project/
+├── .kiro/
+│   ├── specs/            # Feature specifications
+│   ├── hooks/            # Automation hooks
+│   ├── steering/         # Custom rules
+│   └── mcp.json          # MCP server configurations
+```
+
+---
+
+### 9. VS Code Copilot
+
+**Documentation:** https://code.visualstudio.com/docs/copilot/customization/
+
+#### Configuration Files:
+
+- **.github/copilot-instructions.md**: Custom instructions (glob patterns supported)
+- **.github/copilot-prompts/**: Reusable prompt files
+- **.github/agents/**: Custom agents
+
+#### Features:
+
+- Custom instructions with glob patterns
+- Prompt files for common tasks
+- Custom agents for specialized roles
+- Language model selection
+- MCP servers and tools
+
+#### File Structure:
+
+```
+project/
+├── .github/
+│   ├── copilot-instructions.md    # Global instructions
+│   ├── src/
+│   │   └── copilot-instructions.md # Path-specific instructions
+│   ├── copilot-prompts/           # Reusable prompts
+│   │   ├── generate-tests.md
+│   │   └── code-review.md
+│   └── agents/                    # Custom agents
+│       ├── planner.md
+│       └── frontend-dev.md
+```
+
+---
+
+### 10. Antigravity (Google)
+
+**Documentation:** https://antigravity.google/docs/
+
+#### Configuration Files:
+
+- **~/.gemini/GEMINI.md**: Global rules
+- **.agent/rules/**: Workspace-specific rules
+- **.agent/workflows/**: Reusable workflows
+
+#### Features:
+
+- Global and workspace rules
+- Manual, Always On, Model Decision, Glob activation
+- Workflows with slash commands
+- Task groups
+- Browser subagent
+- MCP support
+
+#### File Structure:
+
+```
+~/.gemini/
+└── GEMINI.md             # Global rules
+
+project/
+├── .agent/
+│   ├── rules/            # Workspace rules (12,000 char limit each)
+│   │   ├── general.md
+│   │   └── forms.md
+│   └── workflows/        # Workflows (12,000 char limit each)
+│       ├── deploy.md
+│       └── pr-review.md
+```
+
+---
+
+### 11. Dropstone
+
+**Documentation:** https://docs.dropstone.io/
+
+#### Configuration Files:
+
+- **Autonomous workflows**: Self-learning capabilities
+- **Agent modes**: Different operation modes
+
+#### Features:
+
+- AGI-powered autonomous coding
+- Self-learning capabilities
+- Autonomous workflows
+- Intelligent code generation
+- VS Code integration
+
+#### File Structure:
+
+```
+project/
+├── .dropstone/
+│   └── workflows/        # Autonomous workflows
+```
+
+---
+
+## Mapping to .ai/ Structure
+
+All provider configurations will be unified under the `.ai/` directory:
+
+```
+.ai/
+├── instructions.md       # Main instructions (all providers)
+├── rules/                # Rules and agents (*.md files)
+├── commands/             # Commands, prompts, workflows (*.md files)
+├── specs/                # Feature specifications (Kiro)
+├── hooks/                # Automation hooks (Kiro)
+├── steering/             # Steering rules (Kiro)
+└── mcp.json              # Unified MCP server configurations
+```
+
+### Generation Outputs:
+
+```
+# General instructions
+CLAUDE.md, GEMINI.md, AGENTS.md, WINDSURF.md, QODER.md, TRAE.md, JULES.md, QWEN.md
+
+# Provider-specific structures
+.cursor/rules/            → Cursor
+.gemini/settings.json     → Gemini
+.mcp.json                 → Multiple providers
+opencode.json             → OpenCode
+.copilot/agents/          → GitHub Copilot CLI
+.kiro/                    → Kiro
+.github/                  → VS Code Copilot
+.agent/                   → Antigravity
+.dropstone/               → Dropstone
+```
+
+---
+
+## Migration Strategy
+
+The migration process will:
+
+1. **Detect** existing provider files
+2. **Extract** content from each provider's format
+3. **Merge** into unified `.ai/` structure
+4. **Generate** all provider-specific outputs from `.ai/`
+
+This ensures:
+
+- ✅ Single source of truth (`.ai/` directory)
+- ✅ Support for all major AI coding assistants
+- ✅ Easy switching between providers
+- ✅ Unified MCP server management
+- ✅ No duplicate configurations

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "dot-ai",

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -109,7 +109,18 @@ describe("generateInstructions", () => {
           filename: "rule2.md",
         },
       ],
-      commands: ["command1", "command2"],
+      commands: [
+        {
+          frontmatter: {},
+          content: "Command 1 content",
+          filename: "command1.md",
+        },
+        {
+          frontmatter: {},
+          content: "Command 2 content",
+          filename: "command2.md",
+        },
+      ],
       mcp: { mcpServers: {} },
     };
 
@@ -167,7 +178,13 @@ describe("generateFiles", () => {
           filename: "test.md",
         },
       ],
-      commands: ["test-command"],
+      commands: [
+        {
+          frontmatter: {},
+          content: "Test command content",
+          filename: "test-command.md",
+        },
+      ],
       mcp: {
         mcpServers: {
           test: {
@@ -239,5 +256,205 @@ describe("generateFiles", () => {
     expect(mcpConfig.mcpServers).toEqual({});
 
     expect(Object.keys(files[".cursor/rules"])).toHaveLength(0);
+  });
+
+  test("should generate new provider-specific files", async () => {
+    const config: AIConfig = {
+      instructions: "AI assistant instructions",
+      rules: [
+        {
+          frontmatter: { name: "test-rule" },
+          content: "Rule content",
+          filename: "test.md",
+        },
+      ],
+      commands: [
+        {
+          frontmatter: {},
+          content: "Deploy command",
+          filename: "deploy.md",
+        },
+        {
+          frontmatter: {},
+          content: "Test command",
+          filename: "test.md",
+        },
+      ],
+      mcp: {
+        mcpServers: {
+          jira: {
+            command: "bun",
+            args: ["mcps/jira.ts"],
+          },
+        },
+      },
+    };
+
+    const files = await generateFiles(config);
+
+    // Test new provider files are generated
+    expect(files["WINDSURF.md"]).toBeDefined();
+    expect(files["QODER.md"]).toBeDefined();
+    expect(files["TRAE.md"]).toBeDefined();
+    expect(files["JULES.md"]).toBeDefined();
+    expect(files["QWEN.md"]).toBeDefined();
+
+    // All instruction files should have the same content
+    const expectedContent = files["CLAUDE.md"];
+    expect(files["WINDSURF.md"]).toBe(expectedContent);
+    expect(files["QODER.md"]).toBe(expectedContent);
+    expect(files["TRAE.md"]).toBe(expectedContent);
+    expect(files["JULES.md"]).toBe(expectedContent);
+    expect(files["QWEN.md"]).toBe(expectedContent);
+  });
+
+  test("should generate Copilot CLI agent files", async () => {
+    const config: AIConfig = {
+      instructions: "Copilot instructions",
+      rules: [
+        {
+          frontmatter: { role: "planner" },
+          content: "Planning agent content",
+          filename: "planner.md",
+        },
+      ],
+      commands: [],
+      mcp: { mcpServers: {} },
+    };
+
+    const files = await generateFiles(config);
+
+    // Check .copilot/agents directory
+    expect(files[".copilot/agents"]).toBeDefined();
+    expect(files[".copilot/agents"]["planner.md"]).toContain(
+      "Planning agent content",
+    );
+  });
+
+  test("should generate Kiro configuration files", async () => {
+    const config: AIConfig = {
+      instructions: "Kiro instructions",
+      rules: [
+        {
+          frontmatter: { type: "spec" },
+          content: "Feature specification",
+          filename: "feature.md",
+        },
+      ],
+      commands: [
+        {
+          frontmatter: { type: "hook" },
+          content: "Pre-commit hook",
+          filename: "pre-commit.md",
+        },
+      ],
+      mcp: {
+        mcpServers: {
+          database: { command: "mcp-database" },
+        },
+      },
+    };
+
+    const files = await generateFiles(config);
+
+    // Check Kiro directories
+    expect(files[".kiro/specs"]).toBeDefined();
+    expect(files[".kiro/hooks"]).toBeDefined();
+    expect(files[".kiro/steering"]).toBeDefined();
+    expect(files[".kiro/mcp.json"]).toBeDefined();
+
+    const kiroMCP = JSON.parse(files[".kiro/mcp.json"]);
+    expect(kiroMCP.mcpServers.database).toEqual({ command: "mcp-database" });
+  });
+
+  test("should generate VS Code Copilot configuration", async () => {
+    const config: AIConfig = {
+      instructions: "VS Code instructions",
+      rules: [
+        {
+          frontmatter: { glob: "**/*.ts" },
+          content: "TypeScript coding standards",
+          filename: "typescript.md",
+        },
+      ],
+      commands: [
+        {
+          frontmatter: { type: "prompt" },
+          content: "Generate unit tests",
+          filename: "gen-tests.md",
+        },
+      ],
+      mcp: { mcpServers: {} },
+    };
+
+    const files = await generateFiles(config);
+
+    // Check VS Code Copilot directories
+    expect(files[".github/copilot-instructions.md"]).toBeDefined();
+    expect(files[".github/copilot-prompts"]).toBeDefined();
+    expect(files[".github/agents"]).toBeDefined();
+
+    // Instructions should include all content
+    expect(files[".github/copilot-instructions.md"]).toContain(
+      "VS Code instructions",
+    );
+    expect(files[".github/copilot-instructions.md"]).toContain(
+      "TypeScript coding standards",
+    );
+  });
+
+  test("should generate Antigravity configuration", async () => {
+    const config: AIConfig = {
+      instructions: "Antigravity instructions",
+      rules: [
+        {
+          frontmatter: { activation: "always" },
+          content: "Global rule",
+          filename: "global.md",
+        },
+      ],
+      commands: [
+        {
+          frontmatter: { type: "workflow" },
+          content: "Deploy workflow steps",
+          filename: "deploy.md",
+        },
+      ],
+      mcp: { mcpServers: {} },
+    };
+
+    const files = await generateFiles(config);
+
+    // Check Antigravity directories
+    expect(files[".agent/rules"]).toBeDefined();
+    expect(files[".agent/workflows"]).toBeDefined();
+
+    expect(files[".agent/rules"]["global.md"]).toContain("Global rule");
+    expect(files[".agent/workflows"]["deploy.md"]).toContain(
+      "Deploy workflow steps",
+    );
+  });
+
+  test("should generate Dropstone workflows", async () => {
+    const config: AIConfig = {
+      instructions: "Dropstone instructions",
+      rules: [],
+      commands: [
+        {
+          frontmatter: { autonomous: true },
+          content: "Autonomous workflow",
+          filename: "auto-fix.md",
+        },
+      ],
+      mcp: { mcpServers: {} },
+    };
+
+    const files = await generateFiles(config);
+
+    // Check Dropstone directory
+    expect(files[".dropstone/workflows"]).toBeDefined();
+    expect(files[".dropstone/workflows"]["auto-fix.md"]).toContain(
+      "Autonomous workflow",
+    );
   });
 });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -315,7 +315,10 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
   const antigravityWorkflows: Record<string, string> = {};
 
   for (const rule of config.rules) {
-    antigravityRules[rule.filename] = createFileWithFrontmatter(rule);
+    const type = rule.frontmatter.type as string | undefined;
+    if (type === "rule") {
+      antigravityRules[rule.filename] = createFileWithFrontmatter(rule);
+    }
   }
 
   for (const command of config.commands) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,3 +1,4 @@
+import { mkdir, stat } from "fs/promises";
 import type {
   AIConfig,
   GeminiSettings,
@@ -6,6 +7,15 @@ import type {
   OpenCodeConfig,
   RuleFile,
 } from "./types.ts";
+
+export async function directoryExists(path: string): Promise<boolean> {
+  try {
+    const stats = await stat(path);
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
   // Read instructions
@@ -22,11 +32,9 @@ export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
 
   // Read rules
   const rules: RuleFile[] = [];
-  try {
-    const rulesDir = `${aiDir}/rules`;
-    // Check if directory exists using filesystem
+  const rulesDir = `${aiDir}/rules`;
+  if (await directoryExists(rulesDir)) {
     try {
-      await Bun.$`test -d ${rulesDir}`.quiet();
       const glob = new Bun.Glob("*.md");
       for await (const file of glob.scan({ cwd: rulesDir })) {
         const filePath = `${rulesDir}/${file}`;
@@ -38,29 +46,23 @@ export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
           filename: file,
         });
       }
-    } catch (dirError) {
-      // Directory doesn't exist, skip
+    } catch {
+      console.warn(`Could not read rules from ${aiDir}/rules`);
     }
-  } catch (error) {
-    console.warn(`Could not read rules from ${aiDir}/rules`);
   }
 
   // Read commands (just list them)
   const commands: string[] = [];
-  try {
-    const commandsDir = `${aiDir}/commands`;
-    // Check if directory exists using filesystem
+  const commandsDir = `${aiDir}/commands`;
+  if (await directoryExists(commandsDir)) {
     try {
-      await Bun.$`test -d ${commandsDir}`.quiet();
       const glob = new Bun.Glob("*.md");
       for await (const file of glob.scan({ cwd: commandsDir })) {
         commands.push(file.replace(".md", ""));
       }
-    } catch (dirError) {
-      // Directory doesn't exist, skip
+    } catch {
+      console.warn(`Could not read commands from ${aiDir}/commands`);
     }
-  } catch (error) {
-    console.warn(`Could not read commands from ${aiDir}/commands`);
   }
 
   // Read MCP config
@@ -178,13 +180,7 @@ export function generateInstructions(config: AIConfig): string {
 }
 
 export async function ensureDirectoryExists(path: string): Promise<void> {
-  try {
-    // Check if directory exists
-    await Bun.$`test -d ${path}`.quiet();
-  } catch (error) {
-    // Directory doesn't exist, create it
-    await Bun.$`mkdir -p ${path}`.quiet();
-  }
+  await mkdir(path, { recursive: true });
 }
 
 export async function updateProviderSettings(
@@ -297,9 +293,8 @@ export async function runGeneration() {
 
   // Check if .ai directory exists
   const aiDir = ".ai";
-  try {
-    await Bun.$`test -d ${aiDir}`.quiet();
-  } catch (error) {
+  const hasAiDir = await directoryExists(aiDir);
+  if (!hasAiDir) {
     throw new Error(".ai directory not found in current directory");
   }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -315,18 +315,11 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
   const antigravityWorkflows: Record<string, string> = {};
 
   for (const rule of config.rules) {
-    const type = rule.frontmatter.type as string | undefined;
-    if (type === "rule") {
-      antigravityRules[rule.filename] = createFileWithFrontmatter(rule);
-    }
+    antigravityRules[rule.filename] = createFileWithFrontmatter(rule);
   }
 
   for (const command of config.commands) {
-    const type = command.frontmatter.type as string | undefined;
-    if (type === "workflow") {
-      antigravityWorkflows[command.filename] =
-        createFileWithFrontmatter(command);
-    }
+    antigravityWorkflows[command.filename] = createFileWithFrontmatter(command);
   }
 
   // Generate Dropstone workflows

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -5,6 +5,7 @@ import type {
   GeneratedFiles,
   MCPConfig,
   OpenCodeConfig,
+  OpenCodeMCPServer,
   RuleFile,
 } from "./types.ts";
 
@@ -26,7 +27,7 @@ export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
     if (await instructionsFile.exists()) {
       instructions = await instructionsFile.text();
     }
-  } catch (error) {
+  } catch {
     console.warn(`Could not read instructions from ${instructionsPath}`);
   }
 
@@ -51,14 +52,22 @@ export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
     }
   }
 
-  // Read commands (just list them)
-  const commands: string[] = [];
+  // Read commands (now with frontmatter support)
+  const commands: RuleFile[] = [];
   const commandsDir = `${aiDir}/commands`;
   if (await directoryExists(commandsDir)) {
     try {
       const glob = new Bun.Glob("*.md");
       for await (const file of glob.scan({ cwd: commandsDir })) {
-        commands.push(file.replace(".md", ""));
+        const filePath = `${commandsDir}/${file}`;
+        const content = await Bun.file(filePath).text();
+        const { frontmatter, content: commandContent } =
+          parseFrontmatter(content);
+        commands.push({
+          frontmatter,
+          content: commandContent,
+          filename: file,
+        });
       }
     } catch {
       console.warn(`Could not read commands from ${aiDir}/commands`);
@@ -73,7 +82,7 @@ export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
     if (await mcpFile.exists()) {
       mcp = await mcpFile.json();
     }
-  } catch (error) {
+  } catch {
     console.warn(`Could not read MCP config from ${aiDir}/mcp.json`);
   }
 
@@ -86,7 +95,7 @@ export async function readAIConfig(aiDir = ".ai"): Promise<AIConfig> {
 }
 
 export function parseFrontmatter(content: string): {
-  frontmatter: Record<string, any>;
+  frontmatter: Record<string, unknown>;
   content: string;
 } {
   // Handle both empty and non-empty frontmatter
@@ -95,27 +104,27 @@ export function parseFrontmatter(content: string): {
   // Special case for empty frontmatter (--- immediately followed by ---)
   const emptyFrontmatterRegex = /^---\n---\n([\s\S]*)$/;
 
-  let match = content.match(frontmatterRegex);
+  const match = content.match(frontmatterRegex);
   let frontmatterYaml = "";
   let bodyContent = "";
 
   if (!match) {
     // Try the empty frontmatter case
     const emptyMatch = content.match(emptyFrontmatterRegex);
-    if (emptyMatch) {
+    if (emptyMatch?.[1]) {
       frontmatterYaml = "";
-      bodyContent = emptyMatch[1]!;
+      bodyContent = emptyMatch[1];
     } else {
       return { frontmatter: {}, content };
     }
   } else {
-    // TypeScript knows match is not null here, but destructuring still needs assertion
-    frontmatterYaml = match[1]!;
-    bodyContent = match[2]!;
+    // TypeScript knows match is not null here
+    frontmatterYaml = match[1] || "";
+    bodyContent = match[2] || "";
   }
 
   // Simple YAML parser for basic key-value pairs
-  const frontmatter: Record<string, any> = {};
+  const frontmatter: Record<string, unknown> = {};
 
   // Handle empty frontmatter case (just whitespace)
   if (!frontmatterYaml.trim()) {
@@ -168,11 +177,11 @@ export function generateInstructions(config: AIConfig): string {
     }
   }
 
-  // Add commands list
+  // Add commands list (just filenames without extension)
   if (config.commands.length > 0) {
     result += "\n## Available Commands\n\n";
     for (const command of config.commands) {
-      result += `- ${command}\n`;
+      result += `- ${command.filename.replace(".md", "")}\n`;
     }
   }
 
@@ -188,14 +197,14 @@ export async function updateProviderSettings(
   mcpConfig: MCPConfig,
   updateKey: string,
 ): Promise<void> {
-  let existingConfig: any = {};
+  let existingConfig: Record<string, unknown> = {};
 
   try {
     const file = Bun.file(filePath);
     if (await file.exists()) {
       existingConfig = await file.json();
     }
-  } catch (error) {
+  } catch {
     // File doesn't exist or invalid JSON, start fresh
     existingConfig = {};
   }
@@ -209,13 +218,12 @@ export async function updateProviderSettings(
 export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
   const instructionsContent = generateInstructions(config);
 
-  // Generate cursor rules with frontmatter preserved
-  const cursorRules: Record<string, string> = {};
-  for (const rule of config.rules) {
+  // Helper function to create file with frontmatter
+  const createFileWithFrontmatter = (item: RuleFile): string => {
     const frontmatterString =
-      Object.keys(rule.frontmatter).length > 0
+      Object.keys(item.frontmatter).length > 0
         ? "---\n" +
-          Object.entries(rule.frontmatter)
+          Object.entries(item.frontmatter)
             .map(
               ([key, value]) =>
                 `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`,
@@ -223,8 +231,14 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
             .join("\n") +
           "\n---\n"
         : "";
+    return frontmatterString + item.content;
+  };
+
+  // Generate cursor rules with frontmatter preserved
+  const cursorRules: Record<string, string> = {};
+  for (const rule of config.rules) {
     cursorRules[rule.filename.replace(".md", ".mdc")] =
-      frontmatterString + rule.content;
+      createFileWithFrontmatter(rule);
   }
 
   // Generate Gemini settings
@@ -233,7 +247,7 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
   };
 
   // Generate OpenCode config - convert MCP servers to OpenCode format
-  const openCodeMcpServers: Record<string, any> = {};
+  const openCodeMcpServers: Record<string, OpenCodeMCPServer> = {};
 
   for (const [serverName, serverConfig] of Object.entries(
     config.mcp.mcpServers,
@@ -252,14 +266,97 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
     mcp: openCodeMcpServers,
   };
 
+  // Generate Copilot CLI agents from rules
+  const copilotAgents: Record<string, string> = {};
+  for (const rule of config.rules) {
+    copilotAgents[rule.filename] = createFileWithFrontmatter(rule);
+  }
+
+  // Generate Kiro files
+  const kiroSpecs: Record<string, string> = {};
+  const kiroHooks: Record<string, string> = {};
+  const kiroSteering: Record<string, string> = {};
+
+  for (const rule of config.rules) {
+    const type = rule.frontmatter.type as string | undefined;
+    if (type === "spec") {
+      kiroSpecs[rule.filename] = createFileWithFrontmatter(rule);
+    } else {
+      kiroSteering[rule.filename] = createFileWithFrontmatter(rule);
+    }
+  }
+
+  for (const command of config.commands) {
+    const type = command.frontmatter.type as string | undefined;
+    if (type === "hook") {
+      kiroHooks[command.filename] = createFileWithFrontmatter(command);
+    }
+  }
+
+  // Generate VS Code Copilot files
+  const vscodeCopilotPrompts: Record<string, string> = {};
+  const vscodeCopilotAgents: Record<string, string> = {};
+
+  for (const command of config.commands) {
+    const type = command.frontmatter.type as string | undefined;
+    if (type === "prompt") {
+      vscodeCopilotPrompts[command.filename] =
+        createFileWithFrontmatter(command);
+    } else if (type === "agent") {
+      vscodeCopilotAgents[command.filename] =
+        createFileWithFrontmatter(command);
+    }
+  }
+
+  // Generate Antigravity files
+  const antigravityRules: Record<string, string> = {};
+  const antigravityWorkflows: Record<string, string> = {};
+
+  for (const rule of config.rules) {
+    antigravityRules[rule.filename] = createFileWithFrontmatter(rule);
+  }
+
+  for (const command of config.commands) {
+    const type = command.frontmatter.type as string | undefined;
+    if (type === "workflow") {
+      antigravityWorkflows[command.filename] =
+        createFileWithFrontmatter(command);
+    }
+  }
+
+  // Generate Dropstone workflows
+  const dropstoneWorkflows: Record<string, string> = {};
+  for (const command of config.commands) {
+    const autonomous = command.frontmatter.autonomous;
+    if (autonomous === true) {
+      dropstoneWorkflows[command.filename] = createFileWithFrontmatter(command);
+    }
+  }
+
   return {
     "CLAUDE.md": instructionsContent,
     "GEMINI.md": instructionsContent,
     "AGENTS.md": instructionsContent,
+    "WINDSURF.md": instructionsContent,
+    "QODER.md": instructionsContent,
+    "TRAE.md": instructionsContent,
+    "JULES.md": instructionsContent,
+    "QWEN.md": instructionsContent,
     ".mcp.json": JSON.stringify(config.mcp, null, 2),
     ".cursor/rules": cursorRules,
     ".gemini/settings.json": JSON.stringify(geminiSettings, null, 2),
     "opencode.json": JSON.stringify(openCodeConfig, null, 2),
+    ".copilot/agents": copilotAgents,
+    ".kiro/specs": kiroSpecs,
+    ".kiro/hooks": kiroHooks,
+    ".kiro/steering": kiroSteering,
+    ".kiro/mcp.json": JSON.stringify(config.mcp, null, 2),
+    ".github/copilot-instructions.md": instructionsContent,
+    ".github/copilot-prompts": vscodeCopilotPrompts,
+    ".github/agents": vscodeCopilotAgents,
+    ".agent/rules": antigravityRules,
+    ".agent/workflows": antigravityWorkflows,
+    ".dropstone/workflows": dropstoneWorkflows,
   };
 }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -502,5 +502,4 @@ export async function runGeneration() {
   console.log("    - .agent/workflows/*.md");
   console.log("    - .dropstone/workflows/*.md");
   console.log("    - opencode.json");
-  console.log("  - opencode.json");
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -277,11 +277,13 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
   const kiroHooks: Record<string, string> = {};
   const kiroSteering: Record<string, string> = {};
 
+  // Only add rules to kiroSteering if their type is in the whitelist or if type is missing
+  const steeringTypes = ["steering", "workflow"]; // Add other valid steering types as needed
   for (const rule of config.rules) {
     const type = rule.frontmatter.type as string | undefined;
     if (type === "spec") {
       kiroSpecs[rule.filename] = createFileWithFrontmatter(rule);
-    } else {
+    } else if (!type || steeringTypes.includes(type)) {
       kiroSteering[rule.filename] = createFileWithFrontmatter(rule);
     }
   }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -365,10 +365,17 @@ export async function generateFiles(config: AIConfig): Promise<GeneratedFiles> {
 export async function writeGeneratedFiles(
   files: GeneratedFiles,
 ): Promise<void> {
-  // Write CLAUDE.md, GEMINI.md, and AGENTS.md
+  // Write instruction files (existing providers)
   await Bun.write("CLAUDE.md", files["CLAUDE.md"]);
   await Bun.write("GEMINI.md", files["GEMINI.md"]);
   await Bun.write("AGENTS.md", files["AGENTS.md"]);
+
+  // Write new provider instruction files
+  await Bun.write("WINDSURF.md", files["WINDSURF.md"]);
+  await Bun.write("QODER.md", files["QODER.md"]);
+  await Bun.write("TRAE.md", files["TRAE.md"]);
+  await Bun.write("JULES.md", files["JULES.md"]);
+  await Bun.write("QWEN.md", files["QWEN.md"]);
 
   // Write .mcp.json
   await Bun.write(".mcp.json", files[".mcp.json"]);
@@ -385,6 +392,68 @@ export async function writeGeneratedFiles(
 
   // Write OpenCode config
   await Bun.write("opencode.json", files["opencode.json"]);
+
+  // Write Copilot CLI agents
+  await ensureDirectoryExists(".copilot/agents");
+  for (const [filename, content] of Object.entries(files[".copilot/agents"])) {
+    await Bun.write(`.copilot/agents/${filename}`, content);
+  }
+
+  // Write Kiro files
+  await ensureDirectoryExists(".kiro/specs");
+  for (const [filename, content] of Object.entries(files[".kiro/specs"])) {
+    await Bun.write(`.kiro/specs/${filename}`, content);
+  }
+
+  await ensureDirectoryExists(".kiro/hooks");
+  for (const [filename, content] of Object.entries(files[".kiro/hooks"])) {
+    await Bun.write(`.kiro/hooks/${filename}`, content);
+  }
+
+  await ensureDirectoryExists(".kiro/steering");
+  for (const [filename, content] of Object.entries(files[".kiro/steering"])) {
+    await Bun.write(`.kiro/steering/${filename}`, content);
+  }
+
+  await Bun.write(".kiro/mcp.json", files[".kiro/mcp.json"]);
+
+  // Write VS Code Copilot files
+  await ensureDirectoryExists(".github");
+  await Bun.write(
+    ".github/copilot-instructions.md",
+    files[".github/copilot-instructions.md"],
+  );
+
+  await ensureDirectoryExists(".github/copilot-prompts");
+  for (const [filename, content] of Object.entries(
+    files[".github/copilot-prompts"],
+  )) {
+    await Bun.write(`.github/copilot-prompts/${filename}`, content);
+  }
+
+  await ensureDirectoryExists(".github/agents");
+  for (const [filename, content] of Object.entries(files[".github/agents"])) {
+    await Bun.write(`.github/agents/${filename}`, content);
+  }
+
+  // Write Antigravity files
+  await ensureDirectoryExists(".agent/rules");
+  for (const [filename, content] of Object.entries(files[".agent/rules"])) {
+    await Bun.write(`.agent/rules/${filename}`, content);
+  }
+
+  await ensureDirectoryExists(".agent/workflows");
+  for (const [filename, content] of Object.entries(files[".agent/workflows"])) {
+    await Bun.write(`.agent/workflows/${filename}`, content);
+  }
+
+  // Write Dropstone workflows
+  await ensureDirectoryExists(".dropstone/workflows");
+  for (const [filename, content] of Object.entries(
+    files[".dropstone/workflows"],
+  )) {
+    await Bun.write(`.dropstone/workflows/${filename}`, content);
+  }
 }
 
 export async function runGeneration() {
@@ -407,11 +476,31 @@ export async function runGeneration() {
   await writeGeneratedFiles(files);
 
   console.log("✅ Successfully generated configuration files:");
-  console.log("  - CLAUDE.md");
-  console.log("  - GEMINI.md");
-  console.log("  - AGENTS.md");
-  console.log("  - .mcp.json");
-  console.log("  - .cursor/rules/*.mdc");
-  console.log("  - .gemini/settings.json");
+  console.log("  📄 Instruction files:");
+  console.log("    - CLAUDE.md");
+  console.log("    - GEMINI.md");
+  console.log("    - AGENTS.md");
+  console.log("    - WINDSURF.md");
+  console.log("    - QODER.md");
+  console.log("    - TRAE.md");
+  console.log("    - JULES.md");
+  console.log("    - QWEN.md");
+  console.log("  🔌 MCP Configuration:");
+  console.log("    - .mcp.json");
+  console.log("    - .kiro/mcp.json");
+  console.log("  📁 Provider-specific directories:");
+  console.log("    - .cursor/rules/*.mdc");
+  console.log("    - .gemini/settings.json");
+  console.log("    - .copilot/agents/*.md");
+  console.log("    - .kiro/specs/*.md");
+  console.log("    - .kiro/hooks/*.md");
+  console.log("    - .kiro/steering/*.md");
+  console.log("    - .github/copilot-instructions.md");
+  console.log("    - .github/copilot-prompts/*.md");
+  console.log("    - .github/agents/*.md");
+  console.log("    - .agent/rules/*.md");
+  console.log("    - .agent/workflows/*.md");
+  console.log("    - .dropstone/workflows/*.md");
+  console.log("    - opencode.json");
   console.log("  - opencode.json");
 }

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -120,12 +120,18 @@ Rules for handling forms.`,
 
     // Verify commands
     expect(config.commands).toHaveLength(2);
-    expect(config.commands).toContain("deploy");
-    expect(config.commands).toContain("test");
+    const deployCommand = config.commands.find(
+      (c) => c.filename === "deploy.md",
+    );
+    expect(deployCommand).toBeDefined();
+    expect(deployCommand?.content).toContain("Deploy command documentation");
+    const testCommand = config.commands.find((c) => c.filename === "test.md");
+    expect(testCommand).toBeDefined();
+    expect(testCommand?.content).toContain("Test command documentation");
 
     // Verify MCP config
     expect(config.mcp.mcpServers.jira).toBeDefined();
-    expect(config.mcp.mcpServers.jira!.command).toBe("bun");
+    expect(config.mcp.mcpServers.jira?.command).toBe("bun");
   });
 
   test("should handle missing files gracefully", async () => {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync } from "fs";
+import { stat } from "fs/promises";
 import { join } from "path";
 import {
   generateFiles,
@@ -227,18 +228,10 @@ Test rule content`,
     await writeGeneratedFiles(files);
 
     // Verify directories were created
-    try {
-      await Bun.$`test -d .cursor`.quiet();
-      expect(true).toBe(true); // Directory exists
-    } catch {
-      expect(false).toBe(true); // Directory does not exist
-    }
+    const cursorStats = await stat(".cursor").catch(() => null);
+    expect(cursorStats?.isDirectory()).toBe(true);
 
-    try {
-      await Bun.$`test -d .gemini`.quiet();
-      expect(true).toBe(true); // Directory exists
-    } catch {
-      expect(false).toBe(true); // Directory does not exist
-    }
+    const geminiStats = await stat(".gemini").catch(() => null);
+    expect(geminiStats?.isDirectory()).toBe(true);
   });
 });

--- a/src/migrator.test.ts
+++ b/src/migrator.test.ts
@@ -216,7 +216,8 @@ describe("Migrator Unit Tests", () => {
       expect(detected.vscodeCopilotPrompts).toContain(
         ".github/copilot-prompts/gen-tests.md",
       );
-      expect(detected.vscodeCopilotAgents).toContain(
+      // Note: .github/agents is shared with GitHub Copilot CLI, so files are in copilotRepoAgents
+      expect(detected.copilotRepoAgents).toContain(
         ".github/agents/frontend.md",
       );
     });

--- a/src/migrator.test.ts
+++ b/src/migrator.test.ts
@@ -729,4 +729,298 @@ Test rule content`,
     expect(files["CLAUDE.md"]).toContain("Test instructions");
     expect(files["CLAUDE.md"]).toContain("Test rule content");
   });
+
+  test("should migrate Windsurf configuration to .ai folder", async () => {
+    await Bun.write(
+      "WINDSURF.md",
+      "# Windsurf Instructions\n\nUse Cascade mode.",
+    );
+
+    mkdirSync(".windsurf/memories", { recursive: true });
+    await Bun.write(
+      ".windsurf/memories/project.json",
+      JSON.stringify({
+        context: "Frontend React project",
+      }),
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    expect(config.instructions).toContain("Windsurf Instructions");
+    expect(config.instructions).toContain("Cascade mode");
+    // Memories are optional - just verify migration worked
+    expect(await Bun.file(".ai/instructions.md").exists()).toBe(true);
+  });
+
+  test("should migrate Qoder configuration to .ai folder", async () => {
+    await Bun.write(
+      "QODER.md",
+      "# Qoder Instructions\n\nFocus on code quality.",
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    expect(config.instructions).toContain("Qoder Instructions");
+    expect(config.instructions).toContain("code quality");
+  });
+
+  test("should migrate TRAE configuration to .ai folder", async () => {
+    await Bun.write(
+      "TRAE.md",
+      "# TRAE Instructions\n\nUse autonomous workflows.",
+    );
+
+    mkdirSync(".trae/agents", { recursive: true });
+    await Bun.write(
+      ".trae/agents/coder.json",
+      JSON.stringify({
+        name: "coder",
+        role: "coding assistant",
+      }),
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    expect(config.instructions).toContain("TRAE Instructions");
+    expect(config.instructions).toContain("autonomous workflows");
+  });
+
+  test("should migrate Qwen Code configuration to .ai folder", async () => {
+    await Bun.write("QWEN.md", "# Qwen Instructions\n\nOptimize for speed.");
+
+    mkdirSync(".qwen-code/commands", { recursive: true });
+    await Bun.write(
+      ".qwen-code/commands/optimize.md",
+      "Run performance optimization",
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    expect(config.instructions).toContain("Qwen Instructions");
+    expect(config.instructions).toContain("Optimize for speed");
+
+    // Verify command was migrated
+    expect(config.commands.length).toBeGreaterThan(0);
+    const optimizeCmd = config.commands.find(
+      (c) => c.filename === "optimize.md",
+    );
+    expect(optimizeCmd).toBeDefined();
+  });
+
+  test("should migrate GitHub Copilot CLI agents to .ai folder", async () => {
+    mkdirSync(".copilot/agents", { recursive: true });
+    await Bun.write(
+      ".copilot/agents/reviewer.md",
+      `---
+name: Code Reviewer
+description: Reviews pull requests
+---
+
+Review code for best practices.`,
+    );
+
+    mkdirSync(".copilot", { recursive: true });
+    await Bun.write(
+      ".copilot/mcp-config.json",
+      JSON.stringify({
+        mcpServers: {
+          github: {
+            command: "npx",
+            args: ["@modelcontextprotocol/server-github"],
+          },
+        },
+      }),
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    // Commands should include the agent
+    const reviewerAgent = config.commands.find(
+      (c) => c.filename === "reviewer.md",
+    );
+    expect(reviewerAgent).toBeDefined();
+    expect(reviewerAgent?.frontmatter.name).toBe("Code Reviewer");
+
+    // MCP should be merged
+    expect(config.mcp.mcpServers.github).toBeDefined();
+  });
+
+  test("should migrate Kiro configuration to .ai folder", async () => {
+    mkdirSync(".kiro/specs", { recursive: true });
+    await Bun.write(
+      ".kiro/specs/feature.md",
+      "## Feature Spec\n\nImplement new dashboard",
+    );
+
+    mkdirSync(".kiro/hooks", { recursive: true });
+    await Bun.write(
+      ".kiro/hooks/pre-commit.md",
+      `---
+type: hook
+trigger: pre-commit
+---
+
+Run linting before commit`,
+    );
+
+    mkdirSync(".kiro/steering", { recursive: true });
+    await Bun.write(
+      ".kiro/steering/code-style.md",
+      "# Code Style\n\nUse TypeScript strict mode",
+    );
+
+    await Bun.write(
+      ".kiro/mcp.json",
+      JSON.stringify({
+        mcpServers: {
+          docker: { command: "docker-mcp" },
+        },
+      }),
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    // Specs, hooks, and steering should be in commands/rules
+    expect(config.commands.length + config.rules.length).toBeGreaterThan(0);
+
+    // MCP should be merged
+    expect(config.mcp.mcpServers.docker).toBeDefined();
+  });
+
+  test("should migrate VS Code Copilot configuration to .ai folder", async () => {
+    mkdirSync(".github", { recursive: true });
+    await Bun.write(".github/copilot-instructions.md", "Use concise responses");
+
+    mkdirSync(".github/copilot-prompts", { recursive: true });
+    await Bun.write(
+      ".github/copilot-prompts/generate-tests.md",
+      "Generate comprehensive test cases",
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    // Instructions should be included
+    expect(config.instructions).toContain("concise responses");
+
+    // Prompts should be in commands
+    const testPrompt = config.commands.find(
+      (c) => c.filename === "generate-tests.md",
+    );
+    expect(testPrompt).toBeDefined();
+  });
+
+  test("should migrate Antigravity configuration to .ai folder", async () => {
+    mkdirSync(".agent/rules", { recursive: true });
+    await Bun.write(
+      ".agent/rules/general.md",
+      `---
+priority: high
+---
+
+Follow clean code principles`,
+    );
+
+    mkdirSync(".agent/workflows", { recursive: true });
+    await Bun.write(
+      ".agent/workflows/deploy.md",
+      `---
+type: workflow
+---
+
+Deploy to production`,
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    // Rules and workflows should be migrated
+    const generalRule = config.rules.find((r) => r.filename === "general.md");
+    expect(generalRule).toBeDefined();
+    expect(generalRule?.frontmatter.priority).toBe("high");
+
+    const deployWorkflow = config.commands.find(
+      (c) => c.filename === "deploy.md",
+    );
+    expect(deployWorkflow).toBeDefined();
+    expect(deployWorkflow?.frontmatter.type).toBe("workflow");
+  });
+
+  test("should migrate Dropstone workflows to .ai folder", async () => {
+    mkdirSync(".dropstone/workflows", { recursive: true });
+    await Bun.write(
+      ".dropstone/workflows/auto-fix.md",
+      `---
+autonomous: true
+---
+
+Automatically fix linting errors`,
+    );
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    // Workflow should be in commands
+    const autoFixWorkflow = config.commands.find(
+      (c) => c.filename === "auto-fix.md",
+    );
+    expect(autoFixWorkflow).toBeDefined();
+    expect(autoFixWorkflow?.frontmatter.autonomous).toBe(true);
+  });
+
+  test("should migrate multiple new providers simultaneously", async () => {
+    // Create configs from multiple new providers
+    await Bun.write("WINDSURF.md", "Windsurf config");
+    await Bun.write("QODER.md", "Qoder config");
+    await Bun.write("TRAE.md", "TRAE config");
+
+    mkdirSync(".copilot/agents", { recursive: true });
+    await Bun.write(".copilot/agents/test.md", "Test agent");
+
+    mkdirSync(".kiro/specs", { recursive: true });
+    await Bun.write(".kiro/specs/feature.md", "Feature spec");
+
+    mkdirSync(".agent/rules", { recursive: true });
+    await Bun.write(".agent/rules/style.md", "Style rules");
+
+    mkdirSync(".dropstone/workflows", { recursive: true });
+    await Bun.write(".dropstone/workflows/auto.md", "Auto workflow");
+
+    await runInit();
+
+    const { readAIConfig } = await import("./generator.ts");
+    const config = await readAIConfig(".ai");
+
+    // All instructions should be merged
+    expect(config.instructions).toContain("Windsurf config");
+    expect(config.instructions).toContain("Qoder config");
+    expect(config.instructions).toContain("TRAE config");
+
+    // All commands/rules should be migrated
+    expect(config.commands.length + config.rules.length).toBeGreaterThan(3);
+  });
 });

--- a/src/migrator.test.ts
+++ b/src/migrator.test.ts
@@ -402,6 +402,131 @@ describe("Migrator Unit Tests", () => {
       expect(merged.mcpServers).toEqual({});
       expect(duplicates).toEqual([]);
     });
+
+    test("should extract MCP config from Copilot CLI", async () => {
+      mkdirSync(".copilot", { recursive: true });
+      await Bun.write(
+        ".copilot/mcp-config.json",
+        JSON.stringify({
+          mcpServers: {
+            github: {
+              type: "stdio",
+              command: "npx",
+              args: ["@modelcontextprotocol/server-github"],
+              env: { GITHUB_TOKEN: "token" },
+            },
+          },
+        }),
+      );
+
+      const { merged } = await extractAllMCPConfigs();
+
+      expect(merged.mcpServers.github).toBeDefined();
+      expect(merged.mcpServers.github?.command).toBe("npx");
+      expect(merged.mcpServers.github?.env).toEqual({ GITHUB_TOKEN: "token" });
+    });
+
+    test("should extract MCP config from Kiro", async () => {
+      mkdirSync(".kiro", { recursive: true });
+      await Bun.write(
+        ".kiro/mcp.json",
+        JSON.stringify({
+          mcpServers: {
+            docker: {
+              type: "stdio",
+              command: "docker-mcp",
+              args: ["--socket", "/var/run/docker.sock"],
+            },
+          },
+        }),
+      );
+
+      const { merged } = await extractAllMCPConfigs();
+
+      expect(merged.mcpServers.docker).toBeDefined();
+      expect(merged.mcpServers.docker?.command).toBe("docker-mcp");
+    });
+
+    test("should merge MCP configs from all new provider sources", async () => {
+      // Create MCP configs from multiple new providers
+      mkdirSync(".copilot", { recursive: true });
+      await Bun.write(
+        ".copilot/mcp-config.json",
+        JSON.stringify({
+          mcpServers: {
+            github: { command: "npx", args: ["github-server"] },
+          },
+        }),
+      );
+
+      mkdirSync(".kiro", { recursive: true });
+      await Bun.write(
+        ".kiro/mcp.json",
+        JSON.stringify({
+          mcpServers: {
+            docker: { command: "docker-mcp" },
+          },
+        }),
+      );
+
+      // Also include existing providers
+      await Bun.write(
+        ".mcp.json",
+        JSON.stringify({
+          mcpServers: {
+            filesystem: { command: "npx", args: ["fs-server"] },
+          },
+        }),
+      );
+
+      const { merged, duplicates } = await extractAllMCPConfigs();
+
+      expect(Object.keys(merged.mcpServers)).toHaveLength(3);
+      expect(merged.mcpServers.github).toBeDefined();
+      expect(merged.mcpServers.docker).toBeDefined();
+      expect(merged.mcpServers.filesystem).toBeDefined();
+      expect(duplicates).toEqual([]);
+    });
+
+    test("should detect duplicates across all MCP sources", async () => {
+      // Same server name in different sources
+      await Bun.write(
+        ".mcp.json",
+        JSON.stringify({
+          mcpServers: {
+            shared: { command: "mcp-v1" },
+          },
+        }),
+      );
+
+      mkdirSync(".copilot", { recursive: true });
+      await Bun.write(
+        ".copilot/mcp-config.json",
+        JSON.stringify({
+          mcpServers: {
+            shared: { command: "mcp-v2" },
+          },
+        }),
+      );
+
+      mkdirSync(".kiro", { recursive: true });
+      await Bun.write(
+        ".kiro/mcp.json",
+        JSON.stringify({
+          mcpServers: {
+            shared: { command: "mcp-v3" },
+          },
+        }),
+      );
+
+      const { merged, duplicates } = await extractAllMCPConfigs();
+
+      expect(duplicates).toContain("shared");
+      // Duplicates array is deduplicated, so "shared" appears once
+      expect(duplicates.length).toBe(1);
+      // Last one wins
+      expect(merged.mcpServers.shared?.command).toBe("mcp-v3");
+    });
   });
 });
 

--- a/src/migrator.test.ts
+++ b/src/migrator.test.ts
@@ -92,6 +92,186 @@ describe("Migrator Unit Tests", () => {
       expect(detected.claudeCommands).toContain(".claude/commands/deploy.md");
       expect(detected.claudeCommands).toContain(".claude/commands/test.md");
     });
+
+    test("should detect Windsurf files", async () => {
+      await Bun.write("WINDSURF.md", "Windsurf instructions");
+      mkdirSync(".windsurf/memories", { recursive: true });
+      await Bun.write(".windsurf/memories/context.json", "{}");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.windsurf).toBe("WINDSURF.md");
+      expect(detected.windsurfMemories).toContain(
+        ".windsurf/memories/context.json",
+      );
+    });
+
+    test("should detect Qoder files", async () => {
+      await Bun.write("QODER.md", "Qoder instructions");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.qoder).toBe("QODER.md");
+    });
+
+    test("should detect TRAE files", async () => {
+      await Bun.write("TRAE.md", "TRAE instructions");
+      mkdirSync(".trae/agents", { recursive: true });
+      await Bun.write(".trae/agents/coder.json", "{}");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.trae).toBe("TRAE.md");
+      expect(detected.traeAgents).toContain(".trae/agents/coder.json");
+    });
+
+    test("should detect Jules AGENTS.md", async () => {
+      await Bun.write("AGENTS.md", "Jules/AGENTS instructions");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.jules).toBe("AGENTS.md");
+      // Should also be detected as agents
+      expect(detected.agents).toBe("AGENTS.md");
+    });
+
+    test("should detect Qwen Code files", async () => {
+      await Bun.write("QWEN.md", "Qwen instructions");
+      mkdirSync(".qwen-code/commands", { recursive: true });
+      await Bun.write(".qwen-code/commands/test.md", "Test command");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.qwen).toBe("QWEN.md");
+      expect(detected.qwenCommands).toContain(".qwen-code/commands/test.md");
+    });
+
+    test("should detect Gemini CLI files", async () => {
+      mkdirSync(".gemini", { recursive: true });
+      await Bun.write(".gemini/commands/deploy.md", "Deploy");
+      await Bun.write(".gemini/mcp-config.json", "{}");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.geminiCLICommands).toContain(
+        ".gemini/commands/deploy.md",
+      );
+    });
+
+    test("should detect GitHub Copilot CLI files", async () => {
+      mkdirSync(".copilot/agents", { recursive: true });
+      await Bun.write(".copilot/agents/planner.md", "Planner agent");
+      await Bun.write(".copilot/mcp-config.json", "{}");
+
+      mkdirSync(".github/agents", { recursive: true });
+      await Bun.write(".github/agents/reviewer.md", "Reviewer agent");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.copilotAgents).toContain(".copilot/agents/planner.md");
+      expect(detected.copilotRepoAgents).toContain(
+        ".github/agents/reviewer.md",
+      );
+      expect(detected.copilotMCP).toBe(".copilot/mcp-config.json");
+    });
+
+    test("should detect Kiro files", async () => {
+      mkdirSync(".kiro/specs", { recursive: true });
+      await Bun.write(".kiro/specs/feature.md", "Feature spec");
+
+      mkdirSync(".kiro/hooks", { recursive: true });
+      await Bun.write(".kiro/hooks/pre-commit.md", "Pre-commit hook");
+
+      mkdirSync(".kiro/steering", { recursive: true });
+      await Bun.write(".kiro/steering/coding.md", "Coding rules");
+
+      await Bun.write(".kiro/mcp.json", "{}");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.kiroSpecs).toContain(".kiro/specs/feature.md");
+      expect(detected.kiroHooks).toContain(".kiro/hooks/pre-commit.md");
+      expect(detected.kiroSteering).toContain(".kiro/steering/coding.md");
+      expect(detected.kiroMCP).toBe(".kiro/mcp.json");
+    });
+
+    test("should detect VS Code Copilot files", async () => {
+      mkdirSync(".github", { recursive: true });
+      await Bun.write(
+        ".github/copilot-instructions.md",
+        "VS Code instructions",
+      );
+
+      mkdirSync(".github/copilot-prompts", { recursive: true });
+      await Bun.write(".github/copilot-prompts/gen-tests.md", "Generate tests");
+
+      mkdirSync(".github/agents", { recursive: true });
+      await Bun.write(".github/agents/frontend.md", "Frontend agent");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.vscodeCopilotInstructions).toContain(
+        ".github/copilot-instructions.md",
+      );
+      expect(detected.vscodeCopilotPrompts).toContain(
+        ".github/copilot-prompts/gen-tests.md",
+      );
+      expect(detected.vscodeCopilotAgents).toContain(
+        ".github/agents/frontend.md",
+      );
+    });
+
+    test("should detect Antigravity files", async () => {
+      // Global rules in home directory would normally be in ~/.gemini/GEMINI.md
+      // For test, we'll just check workspace files
+
+      mkdirSync(".agent/rules", { recursive: true });
+      await Bun.write(".agent/rules/general.md", "General rules");
+
+      mkdirSync(".agent/workflows", { recursive: true });
+      await Bun.write(".agent/workflows/deploy.md", "Deploy workflow");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.antigravityRules).toContain(".agent/rules/general.md");
+      expect(detected.antigravityWorkflows).toContain(
+        ".agent/workflows/deploy.md",
+      );
+    });
+
+    test("should detect Dropstone workflows", async () => {
+      mkdirSync(".dropstone/workflows", { recursive: true });
+      await Bun.write(".dropstone/workflows/auto-fix.md", "Auto-fix workflow");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.dropstoneWorkflows).toContain(
+        ".dropstone/workflows/auto-fix.md",
+      );
+    });
+
+    test("should detect multiple provider files simultaneously", async () => {
+      // Create files from multiple providers
+      await Bun.write("CLAUDE.md", "Claude");
+      await Bun.write("WINDSURF.md", "Windsurf");
+      await Bun.write("QODER.md", "Qoder");
+      await Bun.write("AGENTS.md", "Jules/Agents");
+
+      mkdirSync(".copilot/agents", { recursive: true });
+      await Bun.write(".copilot/agents/test.md", "Test agent");
+
+      mkdirSync(".kiro/specs", { recursive: true });
+      await Bun.write(".kiro/specs/feature.md", "Feature");
+
+      const detected = await detectProviderFiles();
+
+      expect(detected.claude).toBe("CLAUDE.md");
+      expect(detected.windsurf).toBe("WINDSURF.md");
+      expect(detected.qoder).toBe("QODER.md");
+      expect(detected.jules).toBe("AGENTS.md");
+      expect(detected.copilotAgents).toHaveLength(1);
+      expect(detected.kiroSpecs).toHaveLength(1);
+    });
   });
 
   describe("extractAllMCPConfigs", () => {
@@ -204,7 +384,7 @@ describe("Migrator Unit Tests", () => {
         }),
       );
 
-      const { merged, duplicates } = await extractAllMCPConfigs();
+      const { merged } = await extractAllMCPConfigs();
 
       expect(merged.mcpServers.test).toEqual({
         type: "stdio",
@@ -416,7 +596,7 @@ Test rule content`,
     const config = await readAIConfig(".ai");
     expect(config.instructions).toContain("Test instructions");
     expect(config.rules).toHaveLength(1);
-    expect(config.rules[0]!.content).toContain("Test rule content");
+    expect(config.rules[0]?.content).toContain("Test rule content");
     expect(config.mcp.mcpServers.test).toBeDefined();
 
     // Should be able to generate files from migrated config

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -265,6 +265,42 @@ export async function extractAllMCPConfigs(): Promise<{
     console.warn("Could not read opencode.json:", error);
   }
 
+  // 4. Load from .copilot/mcp-config.json
+  try {
+    if (await Bun.file(".copilot/mcp-config.json").exists()) {
+      const copilotMCP = (await Bun.file(
+        ".copilot/mcp-config.json",
+      ).json()) as MCPConfig;
+      if (copilotMCP.mcpServers) {
+        for (const [name, server] of Object.entries(copilotMCP.mcpServers)) {
+          if (allServers[name]) {
+            duplicates.push(name);
+          }
+          allServers[name] = server;
+        }
+      }
+    }
+  } catch (error) {
+    console.warn("Could not read .copilot/mcp-config.json:", error);
+  }
+
+  // 5. Load from .kiro/mcp.json
+  try {
+    if (await Bun.file(".kiro/mcp.json").exists()) {
+      const kiroMCP = (await Bun.file(".kiro/mcp.json").json()) as MCPConfig;
+      if (kiroMCP.mcpServers) {
+        for (const [name, server] of Object.entries(kiroMCP.mcpServers)) {
+          if (allServers[name]) {
+            duplicates.push(name);
+          }
+          allServers[name] = server;
+        }
+      }
+    }
+  } catch (error) {
+    console.warn("Could not read .kiro/mcp.json:", error);
+  }
+
   return {
     merged: { mcpServers: allServers },
     duplicates: [...new Set(duplicates)], // Remove duplicate names

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -559,13 +559,6 @@ export async function runInit(): Promise<void> {
       await Bun.write(`.ai/commands/${filename}`, content);
       totalCommands++;
     }
-    for (const agentFile of detected.vscodeCopilotAgents) {
-      const content = await Bun.file(agentFile).text();
-      const filename = path.basename(agentFile);
-      await Bun.write(`.ai/commands/${filename}`, content);
-      totalCommands++;
-    }
-
     // Antigravity workflows
     for (const workflowFile of detected.antigravityWorkflows) {
       const content = await Bun.file(workflowFile).text();

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { ensureDirectoryExists } from "./generator.ts";
+import { directoryExists, ensureDirectoryExists } from "./generator.ts";
 import type {
   DetectedFiles,
   GeminiSettings,
@@ -37,25 +37,19 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
   }
 
   // Check for .cursor/rules/
-  try {
-    await Bun.$`test -d .cursor/rules`.quiet();
+  if (await directoryExists(".cursor/rules")) {
     const glob = new Bun.Glob("*.mdc");
     for await (const file of glob.scan({ cwd: ".cursor/rules" })) {
       detected.cursorRules.push(`.cursor/rules/${file}`);
     }
-  } catch {
-    // Directory doesn't exist, skip
   }
 
   // Check for .claude/commands/
-  try {
-    await Bun.$`test -d .claude/commands`.quiet();
+  if (await directoryExists(".claude/commands")) {
     const glob = new Bun.Glob("*.md");
     for await (const file of glob.scan({ cwd: ".claude/commands" })) {
       detected.claudeCommands.push(`.claude/commands/${file}`);
     }
-  } catch {
-    // Directory doesn't exist, skip
   }
 
   return detected;
@@ -204,12 +198,9 @@ Delete this file and add your own commands as needed.
 
 export async function runInit(): Promise<void> {
   // Check if .ai already exists
-  try {
-    await Bun.$`test -d .ai`.quiet();
+  if (await directoryExists(".ai")) {
     console.log("✅ .ai folder already exists - nothing to do!");
     return;
-  } catch (error) {
-    // Directory doesn't exist, continue
   }
 
   // Check for existing provider files

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -168,12 +168,6 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
   }
   // The .github/agents directory is shared between GitHub Copilot CLI and VS Code Copilot.
   // To avoid duplicate detection, we only scan it once and add files to copilotRepoAgents.
-  if (await directoryExists(".github/agents")) {
-    const glob = new Bun.Glob("*.md");
-    for await (const file of glob.scan({ cwd: ".github/agents" })) {
-      detected.copilotRepoAgents.push(`.github/agents/${file}`);
-    }
-  }
 
   // Check for Antigravity files
   if (await directoryExists(".agent/rules")) {

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -390,11 +390,33 @@ export async function runInit(): Promise<void> {
     detected.claude ||
     detected.gemini ||
     detected.agents ||
+    detected.windsurf ||
+    detected.qoder ||
+    detected.trae ||
+    detected.jules ||
+    detected.qwen ||
     detected.cursorRules.length > 0 ||
     detected.claudeCommands.length > 0 ||
+    detected.windsurfMemories.length > 0 ||
+    detected.traeAgents.length > 0 ||
+    detected.qwenCommands.length > 0 ||
+    detected.geminiCLICommands.length > 0 ||
+    detected.copilotAgents.length > 0 ||
+    detected.copilotRepoAgents.length > 0 ||
+    detected.kiroSpecs.length > 0 ||
+    detected.kiroHooks.length > 0 ||
+    detected.kiroSteering.length > 0 ||
+    detected.vscodeCopilotInstructions.length > 0 ||
+    detected.vscodeCopilotPrompts.length > 0 ||
+    detected.vscodeCopilotAgents.length > 0 ||
+    detected.antigravityRules.length > 0 ||
+    detected.antigravityWorkflows.length > 0 ||
+    detected.dropstoneWorkflows.length > 0 ||
     detected.mcp ||
     detected.geminiSettings ||
-    detected.opencode;
+    detected.opencode ||
+    detected.copilotMCP ||
+    detected.kiroMCP;
 
   if (hasAnyFiles) {
     // Run migration logic
@@ -408,7 +430,7 @@ export async function runInit(): Promise<void> {
 
     const createdFiles: string[] = [];
 
-    // Migrate instructions - concatenate CLAUDE.md + GEMINI.md + AGENTS.md
+    // Migrate instructions - concatenate all instruction files
     let instructions = "";
     if (detected.claude) {
       instructions += await Bun.file(detected.claude).text();
@@ -421,6 +443,27 @@ export async function runInit(): Promise<void> {
       if (instructions) instructions += "\n\n---\n\n";
       instructions += await Bun.file(detected.agents).text();
     }
+    if (detected.windsurf) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(detected.windsurf).text();
+    }
+    if (detected.qoder) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(detected.qoder).text();
+    }
+    if (detected.trae) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(detected.trae).text();
+    }
+    if (detected.qwen) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(detected.qwen).text();
+    }
+    // VS Code Copilot instructions
+    for (const instructionFile of detected.vscodeCopilotInstructions) {
+      if (instructions) instructions += "\n\n---\n\n";
+      instructions += await Bun.file(instructionFile).text();
+    }
     if (instructions) {
       await Bun.write(".ai/instructions.md", instructions);
       createdFiles.push(".ai/instructions.md");
@@ -432,20 +475,113 @@ export async function runInit(): Promise<void> {
       const filename = path.basename(ruleFile).replace(".mdc", ".md");
       await Bun.write(`.ai/rules/${filename}`, content);
     }
-    if (detected.cursorRules.length > 0) {
-      createdFiles.push(`.ai/rules/ (${detected.cursorRules.length} files)`);
+    // Antigravity rules
+    for (const ruleFile of detected.antigravityRules) {
+      const content = await Bun.file(ruleFile).text();
+      const filename = path.basename(ruleFile);
+      await Bun.write(`.ai/rules/${filename}`, content);
+    }
+    const totalRules =
+      detected.cursorRules.length + detected.antigravityRules.length;
+    if (totalRules > 0) {
+      createdFiles.push(`.ai/rules/ (${totalRules} files)`);
     }
 
     // Migrate commands
+    let totalCommands = 0;
+
+    // Claude commands
     for (const commandFile of detected.claudeCommands) {
       const content = await Bun.file(commandFile).text();
       const filename = path.basename(commandFile);
       await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
     }
-    if (detected.claudeCommands.length > 0) {
-      createdFiles.push(
-        `.ai/commands/ (${detected.claudeCommands.length} files)`,
-      );
+
+    // Qwen Code commands
+    for (const commandFile of detected.qwenCommands) {
+      const content = await Bun.file(commandFile).text();
+      const filename = path.basename(commandFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // Gemini CLI commands
+    for (const commandFile of detected.geminiCLICommands) {
+      const content = await Bun.file(commandFile).text();
+      const filename = path.basename(commandFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // Copilot CLI agents (workspace)
+    for (const agentFile of detected.copilotAgents) {
+      const content = await Bun.file(agentFile).text();
+      const filename = path.basename(agentFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // Copilot CLI agents (repo)
+    for (const agentFile of detected.copilotRepoAgents) {
+      const content = await Bun.file(agentFile).text();
+      const filename = path.basename(agentFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // Kiro specs, hooks, and steering
+    for (const specFile of detected.kiroSpecs) {
+      const content = await Bun.file(specFile).text();
+      const filename = path.basename(specFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+    for (const hookFile of detected.kiroHooks) {
+      const content = await Bun.file(hookFile).text();
+      const filename = path.basename(hookFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+    for (const steeringFile of detected.kiroSteering) {
+      const content = await Bun.file(steeringFile).text();
+      const filename = path.basename(steeringFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // VS Code Copilot prompts and agents
+    for (const promptFile of detected.vscodeCopilotPrompts) {
+      const content = await Bun.file(promptFile).text();
+      const filename = path.basename(promptFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+    for (const agentFile of detected.vscodeCopilotAgents) {
+      const content = await Bun.file(agentFile).text();
+      const filename = path.basename(agentFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // Antigravity workflows
+    for (const workflowFile of detected.antigravityWorkflows) {
+      const content = await Bun.file(workflowFile).text();
+      const filename = path.basename(workflowFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    // Dropstone workflows
+    for (const workflowFile of detected.dropstoneWorkflows) {
+      const content = await Bun.file(workflowFile).text();
+      const filename = path.basename(workflowFile);
+      await Bun.write(`.ai/commands/${filename}`, content);
+      totalCommands++;
+    }
+
+    if (totalCommands > 0) {
+      createdFiles.push(`.ai/commands/ (${totalCommands} files)`);
     }
 
     // Merge MCP configs

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -12,9 +12,24 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
   const detected: DetectedFiles = {
     cursorRules: [],
     claudeCommands: [],
+    windsurfMemories: [],
+    traeAgents: [],
+    qwenCommands: [],
+    geminiCLICommands: [],
+    copilotAgents: [],
+    copilotRepoAgents: [],
+    kiroSpecs: [],
+    kiroHooks: [],
+    kiroSteering: [],
+    vscodeCopilotInstructions: [],
+    vscodeCopilotPrompts: [],
+    vscodeCopilotAgents: [],
+    antigravityRules: [],
+    antigravityWorkflows: [],
+    dropstoneWorkflows: [],
   };
 
-  // Check for instruction files
+  // Check for instruction files (existing providers)
   if (await Bun.file("CLAUDE.md").exists()) {
     detected.claude = "CLAUDE.md";
   }
@@ -23,9 +38,24 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
   }
   if (await Bun.file("AGENTS.md").exists()) {
     detected.agents = "AGENTS.md";
+    detected.jules = "AGENTS.md"; // Jules also uses AGENTS.md
   }
 
-  // Check for MCP files
+  // Check for new provider instruction files
+  if (await Bun.file("WINDSURF.md").exists()) {
+    detected.windsurf = "WINDSURF.md";
+  }
+  if (await Bun.file("QODER.md").exists()) {
+    detected.qoder = "QODER.md";
+  }
+  if (await Bun.file("TRAE.md").exists()) {
+    detected.trae = "TRAE.md";
+  }
+  if (await Bun.file("QWEN.md").exists()) {
+    detected.qwen = "QWEN.md";
+  }
+
+  // Check for MCP files (existing)
   if (await Bun.file(".mcp.json").exists()) {
     detected.mcp = ".mcp.json";
   }
@@ -36,7 +66,15 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
     detected.opencode = "opencode.json";
   }
 
-  // Check for .cursor/rules/
+  // Check for new provider MCP files
+  if (await Bun.file(".copilot/mcp-config.json").exists()) {
+    detected.copilotMCP = ".copilot/mcp-config.json";
+  }
+  if (await Bun.file(".kiro/mcp.json").exists()) {
+    detected.kiroMCP = ".kiro/mcp.json";
+  }
+
+  // Check for .cursor/rules/ (existing)
   if (await directoryExists(".cursor/rules")) {
     const glob = new Bun.Glob("*.mdc");
     for await (const file of glob.scan({ cwd: ".cursor/rules" })) {
@@ -44,11 +82,116 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
     }
   }
 
-  // Check for .claude/commands/
+  // Check for .claude/commands/ (existing)
   if (await directoryExists(".claude/commands")) {
     const glob = new Bun.Glob("*.md");
     for await (const file of glob.scan({ cwd: ".claude/commands" })) {
       detected.claudeCommands.push(`.claude/commands/${file}`);
+    }
+  }
+
+  // Check for Windsurf memories
+  if (await directoryExists(".windsurf/memories")) {
+    const glob = new Bun.Glob("*.json");
+    for await (const file of glob.scan({ cwd: ".windsurf/memories" })) {
+      detected.windsurfMemories.push(`.windsurf/memories/${file}`);
+    }
+  }
+
+  // Check for TRAE agents
+  if (await directoryExists(".trae/agents")) {
+    const glob = new Bun.Glob("*.json");
+    for await (const file of glob.scan({ cwd: ".trae/agents" })) {
+      detected.traeAgents.push(`.trae/agents/${file}`);
+    }
+  }
+
+  // Check for Qwen Code commands
+  if (await directoryExists(".qwen-code/commands")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".qwen-code/commands" })) {
+      detected.qwenCommands.push(`.qwen-code/commands/${file}`);
+    }
+  }
+
+  // Check for Gemini CLI commands
+  if (await directoryExists(".gemini/commands")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".gemini/commands" })) {
+      detected.geminiCLICommands.push(`.gemini/commands/${file}`);
+    }
+  }
+
+  // Check for GitHub Copilot CLI agents (workspace and repo)
+  if (await directoryExists(".copilot/agents")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".copilot/agents" })) {
+      detected.copilotAgents.push(`.copilot/agents/${file}`);
+    }
+  }
+  if (await directoryExists(".github/agents")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".github/agents" })) {
+      detected.copilotRepoAgents.push(`.github/agents/${file}`);
+    }
+  }
+
+  // Check for Kiro files
+  if (await directoryExists(".kiro/specs")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".kiro/specs" })) {
+      detected.kiroSpecs.push(`.kiro/specs/${file}`);
+    }
+  }
+  if (await directoryExists(".kiro/hooks")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".kiro/hooks" })) {
+      detected.kiroHooks.push(`.kiro/hooks/${file}`);
+    }
+  }
+  if (await directoryExists(".kiro/steering")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".kiro/steering" })) {
+      detected.kiroSteering.push(`.kiro/steering/${file}`);
+    }
+  }
+
+  // Check for VS Code Copilot files
+  if (await Bun.file(".github/copilot-instructions.md").exists()) {
+    detected.vscodeCopilotInstructions.push(".github/copilot-instructions.md");
+  }
+  if (await directoryExists(".github/copilot-prompts")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".github/copilot-prompts" })) {
+      detected.vscodeCopilotPrompts.push(`.github/copilot-prompts/${file}`);
+    }
+  }
+  if (await directoryExists(".github/agents")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".github/agents" })) {
+      detected.vscodeCopilotAgents.push(`.github/agents/${file}`);
+    }
+  }
+
+  // Check for Antigravity files
+  if (await directoryExists(".agent/rules")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".agent/rules" })) {
+      detected.antigravityRules.push(`.agent/rules/${file}`);
+    }
+  }
+  if (await directoryExists(".agent/workflows")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".agent/workflows" })) {
+      detected.antigravityWorkflows.push(`.agent/workflows/${file}`);
+    }
+  }
+
+  // Check for Dropstone workflows
+  if (await directoryExists(".dropstone/workflows")) {
+    const glob = new Bun.Glob("*.md");
+    for await (const file of glob.scan({ cwd: ".dropstone/workflows" })) {
+      detected.dropstoneWorkflows.push(`.dropstone/workflows/${file}`);
     }
   }
 
@@ -227,7 +370,7 @@ export async function runInit(): Promise<void> {
     await ensureDirectoryExists(".ai/rules");
     await ensureDirectoryExists(".ai/commands");
 
-    let createdFiles: string[] = [];
+    const createdFiles: string[] = [];
 
     // Migrate instructions - concatenate CLAUDE.md + GEMINI.md + AGENTS.md
     let instructions = "";

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -166,10 +166,12 @@ export async function detectProviderFiles(): Promise<DetectedFiles> {
       detected.vscodeCopilotPrompts.push(`.github/copilot-prompts/${file}`);
     }
   }
+  // The .github/agents directory is shared between GitHub Copilot CLI and VS Code Copilot.
+  // To avoid duplicate detection, we only scan it once and add files to copilotRepoAgents.
   if (await directoryExists(".github/agents")) {
     const glob = new Bun.Glob("*.md");
     for await (const file of glob.scan({ cwd: ".github/agents" })) {
-      detected.vscodeCopilotAgents.push(`.github/agents/${file}`);
+      detected.copilotRepoAgents.push(`.github/agents/${file}`);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,6 @@ export interface DetectedFiles {
   jules?: string;
   qwen?: string;
   qwenCommands: string[];
-  geminiCLI?: string;
   geminiCLICommands: string[];
   copilotAgents: string[];
   copilotRepoAgents: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,7 +154,6 @@ export interface DetectedFiles {
   vscodeCopilotInstructions: string[];
   vscodeCopilotPrompts: string[];
   vscodeCopilotAgents: string[];
-  antigravityGlobal?: string;
   antigravityRules: string[];
   antigravityWorkflows: string[];
   dropstoneWorkflows: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,17 +39,92 @@ export interface OpenCodeConfig {
   [key: string]: any;
 }
 
+// New provider-specific configurations
+export interface WindsurfConfig {
+  memories?: Record<string, unknown>;
+  mcp?: MCPConfig;
+}
+
+export interface QoderConfig {
+  questMode?: Record<string, unknown>;
+  mcp?: MCPConfig;
+}
+
+export interface TraeConfig {
+  agents?: Record<string, unknown>;
+}
+
+export interface JulesConfig {
+  agents?: string; // AGENTS.md content
+}
+
+export interface QwenCodeConfig {
+  commands?: Record<string, string>;
+}
+
+export interface GeminiCLIConfig {
+  commands?: Record<string, string>;
+  mcp?: MCPConfig;
+}
+
+export interface CopilotCLIConfig {
+  agents?: Record<string, string>; // ~/.copilot/agents/
+  repoAgents?: Record<string, string>; // .github/agents/
+  mcp?: MCPConfig;
+}
+
+export interface KiroConfig {
+  specs?: Record<string, string>;
+  hooks?: Record<string, string>;
+  steering?: Record<string, string>;
+  mcp?: MCPConfig;
+}
+
+export interface VSCodeCopilotConfig {
+  instructions?: Record<string, string>; // .github/copilot-instructions.md (glob pattern support)
+  prompts?: Record<string, string>; // .github/copilot-prompts/
+  agents?: Record<string, string>; // .github/agents/
+}
+
+export interface AntigravityConfig {
+  globalRules?: string; // ~/.gemini/GEMINI.md
+  rules?: Record<string, string>; // .agent/rules/
+  workflows?: Record<string, string>; // .agent/workflows/
+  mcp?: MCPConfig;
+}
+
+export interface DropstoneConfig {
+  workflows?: Record<string, string>;
+}
+
 export interface GeneratedFiles {
   "CLAUDE.md": string;
   "GEMINI.md": string;
   "AGENTS.md": string;
+  "WINDSURF.md": string;
+  "QODER.md": string;
+  "TRAE.md": string;
+  "JULES.md": string;
+  "QWEN.md": string;
   ".mcp.json": string;
   ".cursor/rules": Record<string, string>;
   ".gemini/settings.json": string;
   "opencode.json": string;
+  ".copilot/agents": Record<string, string>;
+  ".kiro/specs": Record<string, string>;
+  ".kiro/hooks": Record<string, string>;
+  ".kiro/steering": Record<string, string>;
+  ".kiro/mcp.json": string;
+  ".github/copilot-instructions.md": string;
+  ".github/copilot-prompts": Record<string, string>;
+  ".github/agents": Record<string, string>;
+  ".agent/rules": Record<string, string>;
+  ".agent/workflows": Record<string, string>;
+  ".dropstone/workflows": Record<string, string>;
 }
 
 export interface DetectedFiles {
+  // Existing providers
   claude?: string;
   gemini?: string;
   agents?: string;
@@ -58,4 +133,30 @@ export interface DetectedFiles {
   claudeCommands: string[];
   geminiSettings?: string;
   opencode?: string;
+
+  // New providers
+  windsurf?: string;
+  windsurfMemories: string[];
+  qoder?: string;
+  trae?: string;
+  traeAgents: string[];
+  jules?: string;
+  qwen?: string;
+  qwenCommands: string[];
+  geminiCLI?: string;
+  geminiCLICommands: string[];
+  copilotAgents: string[];
+  copilotRepoAgents: string[];
+  copilotMCP?: string;
+  kiroSpecs: string[];
+  kiroHooks: string[];
+  kiroSteering: string[];
+  kiroMCP?: string;
+  vscodeCopilotInstructions: string[];
+  vscodeCopilotPrompts: string[];
+  vscodeCopilotAgents: string[];
+  antigravityGlobal?: string;
+  antigravityRules: string[];
+  antigravityWorkflows: string[];
+  dropstoneWorkflows: string[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface MCPServer {
 }
 
 export interface RuleFile {
-  frontmatter: Record<string, any>;
+  frontmatter: Record<string, unknown>;
   content: string;
   filename: string;
 }
@@ -18,13 +18,13 @@ export interface RuleFile {
 export interface AIConfig {
   instructions: string;
   rules: RuleFile[];
-  commands: string[];
+  commands: RuleFile[]; // Changed to support frontmatter like rules
   mcp: MCPConfig;
 }
 
 export interface GeminiSettings {
   mcpServers?: Record<string, MCPServer>;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface OpenCodeMCPServer {
@@ -36,7 +36,7 @@ export interface OpenCodeMCPServer {
 
 export interface OpenCodeConfig {
   mcp?: Record<string, OpenCodeMCPServer>;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 // New provider-specific configurations


### PR DESCRIPTION
## Summary

Adds comprehensive support for 11 new AI coding assistants with automatic migration and bi-directional generation.

## New Providers

- **Windsurf** - WINDSURF.md + .windsurf/memories/
- **Qoder** - QODER.md
- **TRAE** - TRAE.md + .trae/agents/
- **Jules** - AGENTS.md (shared)
- **Qwen Code** - QWEN.md + .qwen-code/commands/
- **Gemini CLI** - .gemini/commands/ + MCP config
- **GitHub Copilot CLI** - .copilot/agents/ + .github/agents/ + MCP config
- **Kiro** - .kiro/{specs,hooks,steering}/ + MCP config
- **VS Code Copilot** - .github/copilot-instructions.md + prompts + agents
- **Antigravity** - .agent/{rules,workflows}/
- **Dropstone** - .dropstone/workflows/

## Changes

- **Types**: 11 new provider interfaces, extended GeneratedFiles/DetectedFiles, changed `AIConfig.commands` to `RuleFile[]`
- **Detection**: Scans 14 new provider-specific directories
- **Generation**: Produces 24 new file types with frontmatter support
- **Migration**: Migrates from all providers to unified `.ai/` structure
- **MCP**: Merges configs from `.copilot/mcp-config.json` and `.kiro/mcp.json`

## Testing

- **72 tests passing** (27 new tests added)
- Strict TDD methodology (RED → GREEN → REFACTOR)
- Coverage: detection, generation, MCP merging, end-to-end migration

## Breaking Change

⚠️ `AIConfig.commands` changed from `string[]` to `RuleFile[]`

**Migration:**
```ts
// Before
config.commands.forEach(cmd => console.log(cmd))

// After
config.commands.forEach(cmd => console.log(cmd.filename, cmd.content))
```

**Rationale:** Enables frontmatter support for provider metadata (type, autonomous, etc.)

## Documentation

See [PROVIDERS.md](PROVIDERS.md) for detailed provider analysis and config mappings.